### PR TITLE
Remove ssl settings variable

### DIFF
--- a/06_PRC_Handson_User-Training.md
+++ b/06_PRC_Handson_User-Training.md
@@ -71,7 +71,7 @@ with iRODSSession(irods_env_file=env_file) as session:
 In an interactive session, for example, to follow the examples shown in this document, you might want to replace the `with` statement above with:
 
 ```py
-session = iRODSSession(irods_env_file=env_file, **ssl_settings)
+session = iRODSSession(irods_env_file=env_file)
 ```
 
 And at the end of your session clean up with:


### PR DESCRIPTION
SSL settings are already set in the irods_environment.json.

Moreover, if the user didn't specify the ssl_settings variable in the lines before, it will give an error because the variable doesn't exist.